### PR TITLE
fix: run tests on windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,8 @@
 name: Node CI
 
-on: [push]
+on:
+  - push
+  - pull_request
 
 jobs:
   test:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         node_version: [10, 12, 14, 15]
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
     steps:
     - uses: actions/checkout@v1
     - name: Use Node.js ${{ matrix.node_version }}

--- a/cli.js
+++ b/cli.js
@@ -78,7 +78,9 @@ function extensions (arg) {
 }
 
 function stripQuotes (string) {
-  return string.replace(/(^'|")|('|"$)/g, '')
+  if (string.startsWith("'") || string.startsWith('"')) string = string.slice(1);
+  if (string.endsWith("'") || string.endsWith('"')) string = string.slice(0, -1);
+  return string;
 }
 
 check({

--- a/cli.js
+++ b/cli.js
@@ -52,6 +52,10 @@ if (args.help || args._.length === 0) {
   process.exit(1)
 }
 
+// windows leaves leading/trailing quotes on strings needed on unix to
+// stop shells from doing path expansion, so strip them if present
+args._ = args._.map(stripQuotes)
+
 function extensions (arg) {
   if (!arg) return undefined
   const extensions = {}
@@ -71,6 +75,10 @@ function extensions (arg) {
   }
 
   return extensions
+}
+
+function stripQuotes (string) {
+  return string.replace(/(^'|")|('|"$)/g, '')
 }
 
 check({

--- a/cli.js
+++ b/cli.js
@@ -78,9 +78,15 @@ function extensions (arg) {
 }
 
 function stripQuotes (string) {
-  if (string.startsWith("'") || string.startsWith('"')) string = string.slice(1);
-  if (string.endsWith("'") || string.endsWith('"')) string = string.slice(0, -1);
-  return string;
+  if (string.startsWith("'") || string.startsWith('"')) {
+    string = string.slice(1)
+  }
+
+  if (string.endsWith("'") || string.endsWith('"')) {
+    string = string.slice(0, -1)
+  }
+
+  return string
 }
 
 check({

--- a/index.js
+++ b/index.js
@@ -34,12 +34,12 @@ async function resolveGlobbedPath (entries, cwd) {
     expandDirectories: false
   })
 
-  const paths = Object.keys(resolvedEntries.reduce((result, entry) => {
+  const paths = Object.values(resolvedEntries.reduce((result, entry) => {
     // Globby yields unix-style paths.
     const normalized = path.resolve(entry)
 
     if (!result[normalized]) {
-      result[normalized] = true
+      result[normalized] = entry
     }
 
     return result

--- a/index.js
+++ b/index.js
@@ -26,6 +26,9 @@ const promisedResolveModule = (file, options) => new Promise((resolve, reject) =
 async function resolveGlobbedPath (entries, cwd) {
   if (typeof entries === 'string') entries = [entries]
 
+  // replace backslashes for forward slashes for windows
+  entries = entries.map(entry => entry.replace(/\\/g, '/'))
+
   debug('globby resolving', entries)
 
   const resolvedEntries = await globby(entries, {
@@ -34,12 +37,12 @@ async function resolveGlobbedPath (entries, cwd) {
     expandDirectories: false
   })
 
-  const paths = Object.values(resolvedEntries.reduce((result, entry) => {
+  const paths = Object.keys(resolvedEntries.reduce((result, entry) => {
     // Globby yields unix-style paths.
     const normalized = path.resolve(entry)
 
     if (!result[normalized]) {
-      result[normalized] = entry
+      result[normalized] = true
     }
 
     return result

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint": "standard",
     "test-cli:custom-detective": "node cli.js test/ -e js:detective-cjs",
     "test-cli:glob": "node cli.js 'test/**/*.js' --no-default-entries",
+    "test-cli:multi-glob": "node cli.js test/foo.js 'test/*.js' \"test/donkey/*.js\" --no-default-entries",
     "test-cli:main-as-file": "node cli.js test/index.js",
     "test-cli:simple": "node cli.js test/",
     "test-cli": "run-p test-cli:*",


### PR DESCRIPTION
There are two things that break this module on windows:

1. Quoting globbed strings to stop unix shells doing path expansion
  results in the quotes being passed through to globby which breaks
2. Normalising the paths replaces backlashes with forward slashes on
  Windows. Because the code passes them to globby twice, the second
  time round nothing is matched because it doesn't understand forward
  slashes as path separators

So in this PR

1. Strip any leading and trailing quotes from strings
2. Do the path normalisation to dedupe globby's output but return the
  original strings instead