### PR TITLE
Deprecate this module in favor of `knip` (= no final `5.x`)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # dependency-check
 
-**Summer 2023: Deprecated in favor of [`knip`](https://github.com/webpro/knip), which is a way more powerful and comprehensive approach**
+**Spring 2024: Deprecated in favor of [`knip`](https://github.com/webpro/knip), which is a way more powerful and comprehensive approach**
 
 checks which modules you have used in your code and then makes sure they are listed as dependencies in your package.json, or vice-versa
 

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,7 @@
 # dependency-check
 
+**Summer 2023: Deprecated in favor of [`knip`](https://github.com/webpro/knip), which is a way more powerful and comprehensive approach**
+
 checks which modules you have used in your code and then makes sure they are listed as dependencies in your package.json, or vice-versa
 
 [![npm version](https://img.shields.io/npm/v/dependency-check.svg?style=flat)](https://www.npmjs.com/package/dependency-check)


### PR DESCRIPTION
The [`knip`](https://github.com/webpro/knip) module by @webpro is a way more comprehensive and powerful approach to this module and is created for the modern JS ecosystem of today whereas this module comes from a different era and has been a struggle to properly push into the ESM and TS era, especially considering that I'm the only active developer on this project.

I'll leave the deprecation up here for comments before making a final decision.

It will mean that there will be no final version of `5.x`, which likely comes as no surprise to anyone who has been following the very long development phase of it.